### PR TITLE
support grpc client options

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stability_sdk (0.2.2)
+    stability_sdk (0.2.3)
       grpc (>= 1.0.0)
       mime-types (>= 3.0.0)
 

--- a/lib/stability_sdk/client.rb
+++ b/lib/stability_sdk/client.rb
@@ -1,5 +1,6 @@
 require "grpc"
 require "generation_services_pb"
+require "pry"
 
 module StabilitySDK
   class Client
@@ -31,7 +32,12 @@ module StabilitySDK
       call_creds = GRPC::Core::CallCredentials.new(proc { { "authorization" => "Bearer #{options[:api_key]}" } })
       creds = channel_creds.compose(call_creds)
 
-      @stub = Gooseai::GenerationService::Stub.new(host, creds)
+      stub_params = {}
+      [:channel_override, :timeout, :propagate_mask, :channel_args, :interceptors].each do |kw|
+        stub_params[kw] = options[kw] if options.has_key?(kw)
+      end
+
+      @stub = Gooseai::GenerationService::Stub.new(host, creds, **stub_params)
     end
 
     def generate(prompt, options, &block)

--- a/lib/stability_sdk/version.rb
+++ b/lib/stability_sdk/version.rb
@@ -1,3 +1,3 @@
 module StabilitySDK
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/test/stability_sdk_test.rb
+++ b/test/stability_sdk_test.rb
@@ -9,4 +9,9 @@ class StabilitySDKTest < Minitest::Test
     client = StabilitySDK::Client.new(api_key: "test cred")
     assert client.is_a? StabilitySDK::Client
   end
+
+  def test_client_initialization_with_params
+    client = StabilitySDK::Client.new(api_key: "test cred", timeout: 30)
+    assert client.is_a? StabilitySDK::Client
+  end
 end


### PR DESCRIPTION
* https://rubydoc.info/gems/grpc/GRPC/ClientStub#initialize-instance_method

example:

```ruby
client = StabilitySDK::Client.new(api_key: "xyz", timeout: 30)
```