### PR TITLE
specify minimum version of grpc to avoid tls connection error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     stability_sdk (0.2.8)
-      grpc (>= 1.0.0)
+      grpc (>= 1.41.1)
       mime-types (>= 3.0.0)
 
 GEM
@@ -23,6 +23,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  ruby
 
 DEPENDENCIES
   grpc-tools

--- a/stability_sdk.gemspec
+++ b/stability_sdk.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "grpc", ">= 1.0.0"
+  spec.add_dependency "grpc", ">= 1.41.1"
   spec.add_dependency "mime-types", ">= 3.0.0"
   spec.add_development_dependency "grpc-tools"
 end


### PR DESCRIPTION
If a version of the grpc package, which stability-sdk-ruby depends on, is 1.44.0 or smaller, a tls connection error with `grpc.stability.ai` happens. I confirmed this behavior at least at ubuntu 20.04.

The cause of this issue is a bug in grpc C library according to [ssl \- gRPC client doesn't like Let's Encrypt cross\-signed root certs](https://issuecloser.com/blog/grpc-client-doesn-t-like-let-s-encrypt-cross-signed-root-certs). And fixed in [v1.41.1](https://github.com/grpc/grpc/issues/27532#issuecomment-952480401)

# how to produce the error

- pin grpc version to 1.41.0 for examination

```diff
diff --git a/stability_sdk.gemspec b/stability_sdk.gemspec
index 179e6f0..7b78d4c 100644
--- a/stability_sdk.gemspec
+++ b/stability_sdk.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

-  spec.add_dependency "grpc", ">= 1.0.0"
+  spec.add_dependency "grpc", "= 1.41.0"
   spec.add_dependency "mime-types", ">= 3.0.0"
   spec.add_development_dependency "grpc-tools"
 end
```

- `bundle install`
- call the generation API and then received following errors

```ruby
$ bundle exec bin/console

irb(main):002:0> StabilitySDK::Client.new(api_key: "xxx").generate("test", {}) { |answer| answer.artifacts.each { |artifact| p artifact if artifact.type == :ARTIFACT_IMAGE } }

E1003 23:34:00.251251632    2824 ssl_transport_security.cc:1469] Handshake failed with fatal error SSL_ERROR_SSL: error:1000007d:SSL routines:OPENSSL_internal:CERTIFICATE_VERIFY_FAILED.
Traceback (most recent call last):
       16: from /home/ubuntu/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/cli/exec.rb:28:in `run'
       15: from /home/ubuntu/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/cli/exec.rb:63:in `kernel_load'
       14: from /home/ubuntu/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/cli/exec.rb:63:in `load'
       13: from bin/console:14:in `<top (required)>'
       12: from (irb):1
       11: from (irb):2:in `rescue in irb_binding'
       10: from /home/ubuntu/src/github.com/cou929/stability-sdk-ruby/lib/stability_sdk/client.rb:95:in `generate'
        9: from /home/ubuntu/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/grpc-1.41.0-x86_64-linux/src/ruby/lib/grpc/generic/service.rb:181:in `block (3 levels) in rpc_stub_class'
        8: from /home/ubuntu/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/grpc-1.41.0-x86_64-linux/src/ruby/lib/grpc/generic/client_stub.rb:348:in `server_streamer'
        7: from /home/ubuntu/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/grpc-1.41.0-x86_64-linux/src/ruby/lib/grpc/generic/interceptors.rb:170:in `intercept!'
        6: from /home/ubuntu/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/grpc-1.41.0-x86_64-linux/src/ruby/lib/grpc/generic/client_stub.rb:349:in `block in server_streamer'
        5: from /home/ubuntu/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/grpc-1.41.0-x86_64-linux/src/ruby/lib/grpc/generic/active_call.rb:451:in `server_streamer'
        4: from /home/ubuntu/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/grpc-1.41.0-x86_64-linux/src/ruby/lib/grpc/generic/active_call.rb:452:in `rescue in server_streamer'
        3: from /home/ubuntu/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/grpc-1.41.0-x86_64-linux/src/ruby/lib/grpc/generic/active_call.rb:169:in `receive_and_check_status'
        2: from /home/ubuntu/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/grpc-1.41.0-x86_64-linux/src/ruby/lib/grpc/generic/active_call.rb:180:in `attach_status_results_and_complete_call'
        1: from /home/ubuntu/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/grpc-1.41.0-x86_64-linux/src/ruby/lib/grpc/generic/active_call.rb:29:in `check_status'
GRPC::Unavailable (14:failed to connect to all addresses. debug_error_string:{"created":"@1664807640.260630243","description":"Failed to pick subchannel","file":"src/core/ext/filters/client_channel/client_channel.cc","file_line":3158,"referenced_errors":[{"created":"@1664807640.260629411","description":"failed to connect to all addresses","file":"src/core/lib/transport/error_utils.cc","file_line":147,"grpc_status":14}]})
```

The error doesn't occur if set the version of grpc higher than 1.44.1 .