### PR TITLE
Update default engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Options:
     -p, --prefix=VAL                 output prefixes for artifacts. default `generation`
         --no-store                   do not write out artifacts
     -n, --num_samples=VAL            number of samples to generate. default 1
-    -e, --engine=VAL                 engine to use for inference. default `stable-diffusion-v1-5`
+    -e, --engine=VAL                 engine to use for inference. default `stable-diffusion-xl-1024-v1-0`
     -i, --init_image=VAL             path to init image
     -m, --mask_image=VAL             path to mask image
         --start_schedule=VAL         start schedule for init image (must be greater than 0, 1 is full strength text prompt, no trace of image). default 1.0

--- a/lib/stability_sdk/client.rb
+++ b/lib/stability_sdk/client.rb
@@ -8,7 +8,7 @@ module StabilitySDK
     DEFAULT_IMAGE_WIDTH = 512
     DEFAULT_IMAGE_HEIGHT = 512
     DEFAULT_SAMPLE_SIZE = 1
-    DEFAULT_ENGINE_ID = "stable-diffusion-v1-5"
+    DEFAULT_ENGINE_ID = "stable-diffusion-xl-1024-v1-0"
     DEFAULT_CFG_SCALE = 7.0
     DEFAULT_START_SCHEDULE = 1.0
     DEFAULT_END_SCHEDULE = 0.01

--- a/lib/stability_sdk/version.rb
+++ b/lib/stability_sdk/version.rb
@@ -1,3 +1,3 @@
 module StabilitySDK
-  VERSION = "0.3.3"
+  VERSION = "0.3.4"
 end


### PR DESCRIPTION
The current default engine `stable-diffusion-v1-5` will be sunsetted by Nov 15.

ref. [Announcing SDXL 1\.0 — Stability AI](https://stability.ai/blog/stable-diffusion-sdxl-1-announcement)