### PR TITLE
make prompt's weight configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Options:
         --guidance_prompt=VAL        Prompt to use for guidance, defaults to `YOUR_PROMPT_TEXT` argument (above) if not specified.
         --guidance_models=VAL        Models to use for guidance. default nil
     -t, --artifact_types=VAL         filter artifacts by type (ARTIFACT_IMAGE, ARTIFACT_TEXT, ARTIFACT_CLASSIFICATIONS, etc)
+        --prompt_weight=VAL          Weight of the prompt. Currently multi-prompting is not supported yet. default 1"
     -v, --verbose
 ```
 

--- a/exe/stability-client
+++ b/exe/stability-client
@@ -38,6 +38,7 @@ opt.on("--guidance_strength=VAL", Float, "Strength of the guidance. We recommend
 opt.on("--guidance_prompt=VAL", String, "Prompt to use for guidance, defaults to `YOUR_PROMPT_TEXT` argument (above) if not specified.") {|v| options[:guidance_prompt] = v }
 opt.on("--guidance_models=VAL", Array, "Models to use for guidance. default nil") {|v| options[:guidance_models] = v }
 opt.on("-t", "--artifact_types=VAL", Array, "filter artifacts by type (ARTIFACT_IMAGE, ARTIFACT_TEXT, ARTIFACT_CLASSIFICATIONS, etc)") {|v| options[:artifact_types] = v }
+opt.on("--prompt_weight=VAL", Float, "Weight of the prompt. Currently multi-prompting is not supported yet. default 1") {|v| options[:prompt_weight] = v }
 opt.on("-v", "--verbose") { logger.level = Logger::DEBUG }
 opt.parse!(ARGV)
 

--- a/lib/stability_sdk/client.rb
+++ b/lib/stability_sdk/client.rb
@@ -72,10 +72,12 @@ module StabilitySDK
 
       prompt_param = []
       if prompt != ""
-        prompt_param << Gooseai::Prompt.new(text: prompt)
+        param = Gooseai::Prompt.new(text: prompt)
+        param.parameters = Gooseai::PromptParameters.new(weight: options[:prompt_weight]) if options.has_key?(:prompt_weight)
+        prompt_param << param
       end
       if options.has_key?(:init_image)
-        prompt_param << init_image_to_prompt(options[:init_image])
+        prompt_param << init_image_to_prompt(options[:init_image], options[:prompt_weight])
         step_parameter.scaled_step = 0
         step_parameter.sampler = Gooseai::SamplerParameters.new(
           cfg_scale: options.has_key?(:cfg_scale) ? options[:cfg_scale] : DEFAULT_CFG_SCALE,
@@ -168,17 +170,18 @@ module StabilitySDK
       end
     end
 
-    def init_image_to_prompt(path)
+    def init_image_to_prompt(path, weight)
       bin = IO.binread(path)
-      return Gooseai::Prompt.new(
+      prompt = Gooseai::Prompt.new(
         artifact: Gooseai::Artifact.new(
           type: Gooseai::ArtifactType::ARTIFACT_IMAGE,
           binary: bin,
-        ),
-        parameters: Gooseai::PromptParameters.new(
-          init: true
-        ),
+        )
       )
+      unless weight.nil?
+        prompt.parameters = Gooseai::PromptParameters.new(weight: weight)
+      end
+      return prompt
     end
 
     def mask_image_to_prompt(path)


### PR DESCRIPTION
Add an option to set [PromptParamters.weight](https://github.com/Stability-AI/api-interfaces/blob/33560cc3182027a3e156d578902e17b52218429e/src/proto/generation.proto#L78).

:memo: Currently [Multi-prompting](https://platform.stability.ai/docs/features/multi-prompting#Sandbox) is not supported yet.